### PR TITLE
fix rbsod

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -68,16 +68,18 @@ MAGENTIC_ONE_DEFAULT_AGENTS = [
 # Lifespan handler for startup/shutdown events
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    # Startup code
-    # Base.metadata.create_all(bind=engine)
-    # app.state.db = CosmosDB()
+    # Startup code: initialize database and configure logging
+    # app.state.db = None
+    app.state.db = CosmosDB()
+    logging.basicConfig(level=logging.INFO,
+                        format='%(levelname)s: %(asctime)s - %(message)s')
     print("Database initialized.")
     yield
     # Shutdown code (optional)
-    # engine.dispose()
+    # Cleanup database connection
     app.state.db = None
 
-app = FastAPI()
+app = FastAPI(lifespan=lifespan)
 
 # Allow all origins
 app.add_middleware(
@@ -499,15 +501,3 @@ async def delete_team_api(team_id: str):
         return response
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Error deleting team: {str(e)}")
-
-@app.on_event("startup")
-async def startup_event():
-    app.state.db = CosmosDB()
-    # Configure logging with timestamp
-    logging.basicConfig(level=logging.INFO,
-                        format='%(levelname)s: %(asctime)s - %(message)s')
-
-@app.on_event("shutdown")
-async def shutdown_event():
-    # ...any needed cleanup...
-    pass

--- a/frontend/src/pages/Playground.tsx
+++ b/frontend/src/pages/Playground.tsx
@@ -93,7 +93,7 @@ export default function App() {
   // const { teams } = useTeamsContext();
   const { teams, loading } = useTeamsContext();
   const [agents, setAgents] = useState<Agent[]>([]);
-  const [selectedTeam, setSelectedTeam] = useState<Team>(teams[0]);
+  const [selectedTeam, setSelectedTeam] = useState<Team | null>(null);
 
   // Initialize agents from default team (will be updated by sidebar selection)
   // Optionally use an effect to set initial team agents if needed
@@ -103,15 +103,24 @@ export default function App() {
     setSelectedTeam(team);
   }
   
+  // Set initial team once teams are loaded
+  useEffect(() => {
+    if (!loading && teams.length > 0 && selectedTeam === null) {
+      setSelectedTeam(teams[0]);
+      setAgents(teams[0].agents);
+    }
+  }, [loading, teams, selectedTeam]);
+
   // Propagate team changes from TeamsContext to Playground local state
   useEffect(() => {
+    if (!selectedTeam) return;
     const updatedTeam = teams.find(team => team.name === selectedTeam.name);
     if (updatedTeam) {
       setSelectedTeam(updatedTeam);
       setAgents(updatedTeam.agents);
     }
     console.log('Selected team in play:', selectedTeam.name);
-  }, [teams, selectedTeam.name]);
+  }, [teams, selectedTeam?.name]);
 
   const stopSession = async () => {
     try {
@@ -267,14 +276,14 @@ export default function App() {
     }
   }
 
-  if (loading) {
+  if (loading || !selectedTeam) {
     return (
       <ThemeProvider defaultTheme="light" storageKey="vite-ui-theme">
         <SidebarProvider defaultOpen={true}>
           <AppSidebar onTeamSelect={handleTeamSelect} />
           <SidebarInset>
             <div className="flex items-center justify-center h-40">
-              <Loader2 className="h-8 w-8 animate-spin" />  Initialzing...
+              <Loader2 className="h-8 w-8 animate-spin" /> Loading teams...
             </div>
           </SidebarInset>
         </SidebarProvider>


### PR DESCRIPTION
This pull request includes updates to both the backend and frontend to improve initialization, state management, and user experience. Key changes include refactoring the backend's startup/shutdown logic, enhancing logging, and improving the frontend's handling of team selection and loading states.

### Backend Improvements:
* Refactored the lifespan handler in `backend/main.py` to manage database initialization and cleanup, and moved logging configuration to the lifespan startup phase. Removed redundant `@app.on_event` handlers for startup and shutdown. (`[[1]](diffhunk://#diff-df5184bf1f67239fcedd4578cd15b7c94f3f765feabd09c5f20b5831bca33903L71-R82)`, `[[2]](diffhunk://#diff-df5184bf1f67239fcedd4578cd15b7c94f3f765feabd09c5f20b5831bca33903L502-L513)`)

### Frontend Enhancements:
* Updated `Playground.tsx` to initialize `selectedTeam` as `null` instead of defaulting to the first team, improving flexibility and avoiding potential null reference issues. (`[frontend/src/pages/Playground.tsxL96-R96](diffhunk://#diff-b8f5d1da634bd77478c54b767e73a5b40e89b540ec2001c2aeef1f41270e5286L96-R96)`)
* Added a `useEffect` to set the initial team and agents once the teams are loaded, ensuring proper initialization when data becomes available. (`[frontend/src/pages/Playground.tsxR106-R123](diffhunk://#diff-b8f5d1da634bd77478c54b767e73a5b40e89b540ec2001c2aeef1f41270e5286R106-R123)`)
* Adjusted the loading state to account for when `selectedTeam` is not yet set, and updated the loader text for better clarity. (`[frontend/src/pages/Playground.tsxL270-R286](diffhunk://#diff-b8f5d1da634bd77478c54b767e73a5b40e89b540ec2001c2aeef1f41270e5286L270-R286)`)